### PR TITLE
Fix title split

### DIFF
--- a/src/main/java/com/stratio/data/Site.java
+++ b/src/main/java/com/stratio/data/Site.java
@@ -45,7 +45,7 @@ public class Site {
 
     public String[] splitTitle(String fullTitle) {
         String namespace = namespaceStringFromFullTitle(checkNotNull(fullTitle));
-        String title = fullTitle.substring(namespace.length());
+        String title = (namespace.length() == 0) ? fullTitle : fullTitle.substring(namespace.length()+1);
         return new String[]{namespace, title};
     }
 


### PR DESCRIPTION
Currently in cases where namespace is set, the ":" is being retained at the start of the title